### PR TITLE
Adding source plugin and changing jar plugin version for performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,27 +55,30 @@
         </configuration>
       </plugin>
 
-      <!-- Work around a performance issue with Maven and Java 7:
-        Maven has a dependency that does a getgrgid for each file.
-        This is very slow for large groups, and not cached.
-        See issue: http://jira.codehaus.org/browse/PLXCOMP-203
-      -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-io</artifactId>
-            <version>2.0.5</version>
-          </dependency>
-        </dependencies>
+        <version>2.3</version>
         <configuration>
           <archive>
             <!-- include manifest produced by maven-bundle-plugin -->
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.1.2</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Fixes #65.

I downgraded the maven-jar-plugin to 2.3 and not using the latest version of maven-source-plugin because these versions run much faster. 'mvn clean install' runs in less than 8 seconds now for me.