### PR TITLE
Allow waiting for successful start of async commands

### DIFF
--- a/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/CloudSdkAppEngineStandardStaging.java
+++ b/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/CloudSdkAppEngineStandardStaging.java
@@ -74,7 +74,7 @@ public class CloudSdkAppEngineStandardStaging implements AppEngineStandardStagin
 
       cloudSdk.runAppCfgCommand(arguments);
 
-      if (dockerfile != null) {
+      if (dockerfile != null && dockerfile.toFile().exists()) {
         Files.copy(dockerfile, dockerfileDestination, StandardCopyOption.REPLACE_EXISTING);
       }
 

--- a/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/process/AsyncProcessStartWaiter.java
+++ b/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/process/AsyncProcessStartWaiter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.impl.cloudsdk.internal.process;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Provides a mechanism to wait for a successful start of a process by monitoring the process output
+ * and checking for a specific message in it.
+ */
+public class AsyncProcessStartWaiter {
+  private static final Logger log = Logger.getLogger(AsyncProcessStartWaiter.class.toString());
+
+  private final String message;
+  private final int timeoutSeconds;
+  private CountDownLatch waitLatch;
+
+  /**
+   * @param message        The message to look for in the output of the process to consider it to be
+   *                       successfully started. If the message is not seen within the specified
+   *                       timeout, a {@link ProcessRunnerException} will be thrown.
+   * @param timeoutSeconds The maximum number of seconds to wait for the message to be seen until
+   *                       giving up. If set to 0, will skip waiting.
+   */
+  public AsyncProcessStartWaiter(String message, int timeoutSeconds) {
+    this.message = message;
+    this.timeoutSeconds = timeoutSeconds;
+  }
+
+  /**
+   * Prepares the internal latch for monitoring messages and waiting.
+   */
+  public void reset() {
+    if (waitLatch != null) {
+      waitLatch.countDown();
+    }
+    waitLatch = new CountDownLatch(1);
+  }
+
+  /**
+   * Blocks the executing thread until the specified message is seen through {@link
+   * #inputLine(String)}. If the message is not seen within the specified timeout, {@link
+   * ProcessRunnerException} will be thrown.
+   */
+  public void await() throws InterruptedException, ProcessRunnerException {
+    try {
+      if (message != null && timeoutSeconds != 0) {
+        log.info("Waiting " + timeoutSeconds
+            + " seconds for the operation to succeed...");
+        if (!waitLatch.await(timeoutSeconds, TimeUnit.SECONDS)) {
+          log.warning("Operation failed.");
+          throw new ProcessRunnerException("Timed out waiting for the success message: '"
+              + message + "'");
+        } else {
+          log.info("Operation succeeded.");
+        }
+      }
+    } finally {
+      waitLatch.countDown();
+    }
+  }
+
+  /**
+   * Monitors the output of the process to check whether the wait condition is satisfied.
+   */
+  public void inputLine(String line) {
+    if (waitLatch.getCount() > 0 && message != null && line.contains(message)) {
+      waitLatch.countDown();
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/process/DefaultProcessRunner.java
+++ b/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/process/DefaultProcessRunner.java
@@ -17,12 +17,10 @@ package com.google.cloud.tools.app.impl.cloudsdk.internal.process;
 import static java.lang.ProcessBuilder.Redirect;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
-
 
 
 /**
@@ -30,19 +28,26 @@ import java.util.Scanner;
  * monitoring output and checking the exit code of the child process.
  */
 public class DefaultProcessRunner implements ProcessRunner {
-  private boolean async;
-  private List<ProcessOutputLineListener> stdOutLineListeners;
-  private List<ProcessOutputLineListener> stdErrLineListeners;
-  private ProcessExitListener exitListener;
+  private final boolean async;
+  private final List<ProcessOutputLineListener> stdOutLineListeners;
+  private final List<ProcessOutputLineListener> stdErrLineListeners;
+  private final ProcessExitListener exitListener;
 
-  private ProcessBuilder processBuilder = new ProcessBuilder();
   private Process process;
 
   private Map<String, String> environment;
 
-  private DefaultProcessRunner(boolean async, List<ProcessOutputLineListener> stdOutLineListeners,
-                               List<ProcessOutputLineListener> stdErrLineListeners,
-                               ProcessExitListener exitListener) {
+  /**
+   * @param async               Whether to run commands asynchronously
+   * @param stdOutLineListeners Client consumers of process standard output. If empty, output will
+   *                            be inherited by parent process.
+   * @param stdErrLineListeners Client consumers of process error output. If empty, output will be
+   *                            inherited by parent process.
+   * @param exitListener        Client consumer of process exit event.
+   */
+  public DefaultProcessRunner(boolean async, List<ProcessOutputLineListener> stdOutLineListeners,
+                              List<ProcessOutputLineListener> stdErrLineListeners,
+                              ProcessExitListener exitListener) {
     this.async = async;
     this.stdOutLineListeners = stdOutLineListeners;
     this.stdErrLineListeners = stdErrLineListeners;
@@ -201,54 +206,4 @@ public class DefaultProcessRunner implements ProcessRunner {
     }
     return osCommand;
   }
-
-  public static class Builder {
-    private boolean async = false;
-    private List<ProcessOutputLineListener> stdOutLineListeners = new ArrayList<>();
-    private List<ProcessOutputLineListener> stdErrLineListeners = new ArrayList<>();
-    private ProcessExitListener exitListener;
-    private WaitingProcessOutputLineListener waitingProcessOutputLineListener;
-
-    /**
-     * Whether to run commands asynchronously.
-     */
-    public Builder async(boolean async) {
-      this.async = async;
-      return this;
-    }
-
-    /**
-     * Adds a client consumer of process standard output.
-     */
-    public Builder addStdOutLineListener(ProcessOutputLineListener stdOutLineListener) {
-      this.stdOutLineListeners.add(stdOutLineListener);
-      return this;
-    }
-
-    /**
-     * Adds a client consumer of process error output.
-     */
-    public Builder addStdErrLineListener(ProcessOutputLineListener stdErrLineListener) {
-      this.stdErrLineListeners.add(stdErrLineListener);
-      return this;
-    }
-
-    /**
-     * The client listener of the process exit with code.
-     */
-    public Builder exitListener(ProcessExitListener exitListener) {
-      this.exitListener = exitListener;
-      return this;
-    }
-
-    /**
-     * Create a new instance of {@link DefaultProcessRunner}.
-     */
-    public DefaultProcessRunner build() {
-      return new DefaultProcessRunner(async, stdOutLineListeners, stdErrLineListeners,
-          exitListener);
-    }
-
-  }
-
 }

--- a/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/process/DefaultProcessRunner.java
+++ b/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/process/DefaultProcessRunner.java
@@ -19,34 +19,36 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 
 /**
  * Default process runner that allows synchronous or asynchronous execution. It also allows
  * monitoring output and checking the exit code of the child process.
  */
 public class DefaultProcessRunner implements ProcessRunner {
+  private static final Logger log = Logger.getLogger(DefaultProcessRunner.class.toString());
 
-  private ProcessBuilder processBuilder;
-  private boolean async = false;
+  private boolean async;
   private ProcessOutputLineListener stdOutLineListener;
   private ProcessOutputLineListener stdErrLineListener;
   private ProcessExitListener exitListener;
+  private String waitSuccessMessage;
+  private int waitSuccessTimeoutSeconds;
 
   private Process process;
+  private CountDownLatch waitSuccessLatch;
 
-  /**
-   * Create the process runner with a default process builder, with inheritIO enabled.
-   */
-  public DefaultProcessRunner() {
-    this(new ProcessBuilder());
-    processBuilder.inheritIO();
-  }
+  private Map<String, String> environment;
 
-  /**
-   * Create the process runner with the provided process builder.
-   */
-  public DefaultProcessRunner(ProcessBuilder processBuilder) {
-    this.processBuilder = processBuilder;
+  private DefaultProcessRunner(Builder builder) {
+    this.async = builder.async;
+    this.stdOutLineListener = builder.stdOutLineListener;
+    this.stdErrLineListener = builder.stdErrLineListener;
+    this.exitListener = builder.exitListener;
+    this.waitSuccessMessage = builder.waitSuccessMessage;
+    this.waitSuccessTimeoutSeconds = builder.waitSuccessTimeoutSeconds;
   }
 
   /**
@@ -57,6 +59,12 @@ public class DefaultProcessRunner implements ProcessRunner {
   public void run(String[] command) throws ProcessRunnerException {
     try {
 
+      waitSuccessLatch = new CountDownLatch(1);
+
+      final ProcessBuilder processBuilder = new ProcessBuilder();
+      if (environment != null) {
+        processBuilder.environment().putAll(environment);
+      }
       processBuilder.command(makeOsSpecific(command));
 
       synchronized (this) {
@@ -79,6 +87,7 @@ public class DefaultProcessRunner implements ProcessRunner {
         syncRun(process);
       }
 
+      handleWaitSuccess();
 
     } catch (IOException | InterruptedException | IllegalThreadStateException e) {
       throw new ProcessRunnerException(e);
@@ -86,10 +95,10 @@ public class DefaultProcessRunner implements ProcessRunner {
   }
 
   /**
-   * @param environment Environment variables to append to the current system environment variables.
+   * Environment variables to append to the current system environment variables.
    */
   public void setEnvironment(Map<String, String> environment) {
-    processBuilder.environment().putAll(environment);
+    this.environment = environment;
   }
 
   /**
@@ -124,49 +133,79 @@ public class DefaultProcessRunner implements ProcessRunner {
   /**
    * Sets the subprocess exit listener for collecting the exit code of the subprocess.
    *
-   * @param exitListener Can be nul.
+   * @param exitListener Can be null.
    */
   public void setExitListener(ProcessExitListener exitListener) {
     this.exitListener = exitListener;
   }
 
   /**
-   * @return The process that is currently executing or was the last one to be started using the run
-   *     method.
+   * The process that is currently executing or was the last one to be started using the run
+   * method.
    */
   public Process getProcess() {
     return this.process;
   }
 
   private void handleErrOut(final Process process) {
-    if (stdErrLineListener != null) {
-      final Scanner stdErr = new Scanner(process.getErrorStream());
-      Thread stdErrThread = new Thread("standard-err") {
-        public void run() {
-          while (stdErr.hasNextLine() && !Thread.interrupted()) {
-            String line = stdErr.nextLine();
-            stdErrLineListener.outputLine(line);
-          }
+    final Scanner stdErr = new Scanner(process.getErrorStream());
+    Thread stdErrThread = new Thread("standard-err") {
+      public void run() {
+        while (stdErr.hasNextLine() && !Thread.interrupted()) {
+          String line = stdErr.nextLine();
+          consumeLine(line, true);
         }
-      };
-      stdErrThread.setDaemon(true);
-      stdErrThread.start();
-    }
+      }
+    };
+    stdErrThread.setDaemon(true);
+    stdErrThread.start();
   }
 
   private void handleStdOut(final Process process) {
-    if (stdOutLineListener != null) {
-      final Scanner stdOut = new Scanner(process.getInputStream());
-      Thread stdOutThread = new Thread("standard-out") {
-        public void run() {
-          while (stdOut.hasNextLine() && !Thread.interrupted()) {
-            String line = stdOut.nextLine();
-            stdOutLineListener.outputLine(line);
-          }
+    final Scanner stdOut = new Scanner(process.getInputStream());
+    Thread stdOutThread = new Thread("standard-out") {
+      public void run() {
+        while (stdOut.hasNextLine() && !Thread.interrupted()) {
+          String line = stdOut.nextLine();
+          consumeLine(line, false);
         }
-      };
-      stdOutThread.setDaemon(true);
-      stdOutThread.start();
+      }
+    };
+    stdOutThread.setDaemon(true);
+    stdOutThread.start();
+  }
+
+  private void handleWaitSuccess() throws InterruptedException, ProcessRunnerException {
+    try {
+      if (async && waitSuccessMessage != null && waitSuccessTimeoutSeconds != 0) {
+        log.info("Waiting " + waitSuccessTimeoutSeconds
+            + " seconds for the operation to succeed...");
+        if (!waitSuccessLatch.await(waitSuccessTimeoutSeconds, TimeUnit.SECONDS)) {
+          log.warning("Operation failed.");
+          throw new ProcessRunnerException("Timed out waiting for the success message: '"
+              + waitSuccessMessage + "'");
+        } else {
+          log.info("Operation succeeded.");
+        }
+      }
+    } finally {
+      waitSuccessLatch.countDown();
+    }
+  }
+
+  private void consumeLine(String line, boolean errorStream) {
+    if (errorStream) {
+      if (stdErrLineListener != null) {
+        stdErrLineListener.outputLine(line);
+      }
+    } else {
+      if (stdOutLineListener != null) {
+        stdOutLineListener.outputLine(line);
+      }
+    }
+
+    if (waitSuccessMessage != null && line.contains(waitSuccessMessage)) {
+      waitSuccessLatch.countDown();
     }
   }
 
@@ -219,4 +258,72 @@ public class DefaultProcessRunner implements ProcessRunner {
     return osCommand;
   }
 
+  public static class Builder {
+    private boolean async = false;
+    private ProcessOutputLineListener stdOutLineListener;
+    private ProcessOutputLineListener stdErrLineListener;
+    private ProcessExitListener exitListener;
+    private String waitSuccessMessage;
+    private int waitSuccessTimeoutSeconds = 30;
+
+    /**
+     * Whether to run commands asynchronously.
+     */
+    public Builder async(boolean async) {
+      this.async = async;
+      return this;
+    }
+
+    /**
+     * The client consumer of process standard output.
+     */
+    public Builder stdOutLineListener(ProcessOutputLineListener stdOutLineListener) {
+      this.stdOutLineListener = stdOutLineListener;
+      return this;
+    }
+
+    /**
+     * The client consumer of process error output.
+     */
+    public Builder stdErrLineListener(ProcessOutputLineListener stdErrLineListener) {
+      this.stdErrLineListener = stdErrLineListener;
+      return this;
+    }
+
+    /**
+     * The client listener of the process exit with code.
+     */
+    public Builder exitListener(ProcessExitListener exitListener) {
+      this.exitListener = exitListener;
+      return this;
+    }
+
+    /**
+     * The message to look for in the standard or error output of the process to consider it to be
+     * successfully started. If the message is not seen within the specified timeout {@link
+     * #waitSuccessTimeoutSeconds(int)}, a {@link ProcessRunnerException} will be thrown.
+     */
+    public Builder waitSuccessMessage(String waitSuccessMessage) {
+      this.waitSuccessMessage = waitSuccessMessage;
+      return this;
+    }
+
+    /**
+     * The number of seconds to wait for after starting the process to see the {@link
+     * #waitSuccessMessage(String)} in the process output. If set to 0, will not wait at all and
+     * pass. Default is 30 seconds.
+     */
+    public Builder waitSuccessTimeoutSeconds(int waitSuccessTimeoutSeconds) {
+      this.waitSuccessTimeoutSeconds = waitSuccessTimeoutSeconds;
+      return this;
+    }
+
+    /**
+     * Create a new instance of {@link DefaultProcessRunner}.
+     */
+    public DefaultProcessRunner build() {
+      return new DefaultProcessRunner(this);
+    }
+
+  }
 }

--- a/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/process/ProcessRunnerException.java
+++ b/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/process/ProcessRunnerException.java
@@ -22,4 +22,8 @@ public class ProcessRunnerException extends Exception {
   public ProcessRunnerException(Exception cause) {
     super(cause);
   }
+
+  public ProcessRunnerException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/process/WaitingProcessOutputLineListener.java
+++ b/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/process/WaitingProcessOutputLineListener.java
@@ -54,14 +54,15 @@ public class WaitingProcessOutputLineListener implements ProcessOutputLineListen
    * #outputLine(String)}. If the message is not seen within the specified timeout, {@link
    * ProcessRunnerException} will be thrown.
    */
-  public void await() throws InterruptedException, ProcessRunnerException {
+  public void await() throws ProcessRunnerException {
     try {
-      if (message != null && timeoutSeconds != 0) {
-        if (!waitLatch.await(timeoutSeconds, TimeUnit.SECONDS)) {
-          throw new ProcessRunnerException("Timed out waiting for the success message: '"
-              + message + "'");
-        }
+      if (message != null && timeoutSeconds != 0
+          && !waitLatch.await(timeoutSeconds, TimeUnit.SECONDS)) {
+        throw new ProcessRunnerException("Timed out waiting for the success message: '"
+            + message + "'");
       }
+    } catch (InterruptedException e) {
+      throw new ProcessRunnerException(e);
     } finally {
       waitLatch.countDown();
     }

--- a/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/sdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/sdk/CloudSdk.java
@@ -263,7 +263,7 @@ public class CloudSdk {
     public CloudSdk build() {
       // Default process runner
       if (processRunner == null) {
-        processRunner = new DefaultProcessRunner();
+        processRunner = new DefaultProcessRunner.Builder().build();
       }
 
       // Default SDK path

--- a/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/sdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/sdk/CloudSdk.java
@@ -54,14 +54,16 @@ public class CloudSdk {
   private final File appCommandCredentialFile;
   private final String appCommandOutputFormat;
 
-  private CloudSdk(Builder builder) {
-    this.sdkPath = builder.sdkPath;
-    this.processRunner = builder.processRunner;
-    this.appCommandMetricsEnvironment = builder.appCommandMetricsEnvironment;
-    this.appCommandMetricsEnvironmentVersion = builder.appCommandMetricsEnvironmentVersion;
-    this.appCommandGsUtil = builder.appCommandGsUtil;
-    this.appCommandCredentialFile = builder.appCommandCredentialFile;
-    this.appCommandOutputFormat = builder.appCommandOutputFormat;
+  private CloudSdk(Path sdkPath, ProcessRunner processRunner, String appCommandMetricsEnvironment,
+                  String appCommandMetricsEnvironmentVersion, Integer appCommandGsUtil,
+                  File appCommandCredentialFile, String appCommandOutputFormat) {
+    this.sdkPath = sdkPath;
+    this.processRunner = processRunner;
+    this.appCommandMetricsEnvironment = appCommandMetricsEnvironment;
+    this.appCommandMetricsEnvironmentVersion = appCommandMetricsEnvironmentVersion;
+    this.appCommandGsUtil = appCommandGsUtil;
+    this.appCommandCredentialFile = appCommandCredentialFile;
+    this.appCommandOutputFormat = appCommandOutputFormat;
   }
 
   /**
@@ -301,7 +303,9 @@ public class CloudSdk {
         sdkPath = discoveredSdkPath;
       }
 
-      return new CloudSdk(this);
+      return new CloudSdk(sdkPath, processRunner, appCommandMetricsEnvironment,
+          appCommandMetricsEnvironmentVersion, appCommandGsUtil, appCommandCredentialFile,
+          appCommandOutputFormat);
     }
 
   }

--- a/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/sdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/sdk/CloudSdk.java
@@ -15,7 +15,10 @@
 package com.google.cloud.tools.app.impl.cloudsdk.internal.sdk;
 
 import com.google.cloud.tools.app.api.AppEngineException;
+import com.google.cloud.tools.app.impl.cloudsdk.internal.process.AsyncProcessStartWaiter;
 import com.google.cloud.tools.app.impl.cloudsdk.internal.process.DefaultProcessRunner;
+import com.google.cloud.tools.app.impl.cloudsdk.internal.process.ProcessExitListener;
+import com.google.cloud.tools.app.impl.cloudsdk.internal.process.ProcessOutputLineListener;
 import com.google.cloud.tools.app.impl.cloudsdk.internal.process.ProcessRunner;
 import com.google.cloud.tools.app.impl.cloudsdk.internal.process.ProcessRunnerException;
 import com.google.cloud.tools.app.impl.cloudsdk.util.Args;
@@ -195,6 +198,7 @@ public class CloudSdk {
     private Integer appCommandGsUtil;
     private File appCommandCredentialFile;
     private String appCommandOutputFormat;
+    private DefaultProcessRunner.Builder processRunnerBuilder = new DefaultProcessRunner.Builder();
 
     /**
      * The home directory of Google Cloud SDK. If not set, will attempt to look for the SDK in known
@@ -204,14 +208,6 @@ public class CloudSdk {
       if (sdkPathFile != null) {
         this.sdkPath = sdkPathFile.toPath();
       }
-      return this;
-    }
-
-    /**
-     * The process runner used to execute CLI commands.
-     */
-    public Builder processRunner(ProcessRunner processRunner) {
-      this.processRunner = processRunner;
       return this;
     }
 
@@ -258,13 +254,52 @@ public class CloudSdk {
     }
 
     /**
+     * Whether to run commands asynchronously.
+     */
+    public Builder async(boolean async) {
+      this.processRunnerBuilder.async(async);
+      return this;
+    }
+
+    /**
+     * The client consumer of process standard output.
+     */
+    public Builder stdOutLineListener(ProcessOutputLineListener stdOutLineListener) {
+      this.processRunnerBuilder.stdOutLineListener(stdOutLineListener);
+      return this;
+    }
+
+    /**
+     * The client consumer of process error output.
+     */
+    public Builder stdErrLineListener(ProcessOutputLineListener stdErrLineListener) {
+      this.processRunnerBuilder.stdErrLineListener(stdErrLineListener);
+      return this;
+    }
+
+    /**
+     * The client listener of the process exit with code.
+     */
+    public Builder exitListener(ProcessExitListener exitListener) {
+      this.processRunnerBuilder.exitListener(exitListener);
+      return this;
+    }
+
+    /**
+     * {@link AsyncProcessStartWaiter} used to block the thread until the asynchronous process has
+     * started successfully.
+     */
+    public Builder asyncProcessStartWaiter(AsyncProcessStartWaiter asyncProcessStartWaiter) {
+      this.processRunnerBuilder.asyncProcessStartWaiter(asyncProcessStartWaiter);
+      return this;
+    }
+
+    /**
      * Create a new instance of {@link CloudSdk}.
      */
     public CloudSdk build() {
-      // Default process runner
-      if (processRunner == null) {
-        processRunner = new DefaultProcessRunner.Builder().build();
-      }
+      // create process runner
+      processRunner = processRunnerBuilder.build();
 
       // Default SDK path
       if (sdkPath == null) {

--- a/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/sdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/app/impl/cloudsdk/internal/sdk/CloudSdk.java
@@ -15,7 +15,6 @@
 package com.google.cloud.tools.app.impl.cloudsdk.internal.sdk;
 
 import com.google.cloud.tools.app.api.AppEngineException;
-import com.google.cloud.tools.app.impl.cloudsdk.internal.process.AsyncProcessStartWaiter;
 import com.google.cloud.tools.app.impl.cloudsdk.internal.process.DefaultProcessRunner;
 import com.google.cloud.tools.app.impl.cloudsdk.internal.process.ProcessExitListener;
 import com.google.cloud.tools.app.impl.cloudsdk.internal.process.ProcessOutputLineListener;
@@ -262,18 +261,18 @@ public class CloudSdk {
     }
 
     /**
-     * The client consumer of process standard output.
+     * Adds a client consumer of process standard output.
      */
-    public Builder stdOutLineListener(ProcessOutputLineListener stdOutLineListener) {
-      this.processRunnerBuilder.stdOutLineListener(stdOutLineListener);
+    public Builder addStdOutLineListener(ProcessOutputLineListener stdOutLineListener) {
+      this.processRunnerBuilder.addStdOutLineListener(stdOutLineListener);
       return this;
     }
 
     /**
-     * The client consumer of process error output.
+     * Adds a client consumer of process error output.
      */
-    public Builder stdErrLineListener(ProcessOutputLineListener stdErrLineListener) {
-      this.processRunnerBuilder.stdErrLineListener(stdErrLineListener);
+    public Builder addStdErrLineListener(ProcessOutputLineListener stdErrLineListener) {
+      this.processRunnerBuilder.addStdErrLineListener(stdErrLineListener);
       return this;
     }
 
@@ -282,15 +281,6 @@ public class CloudSdk {
      */
     public Builder exitListener(ProcessExitListener exitListener) {
       this.processRunnerBuilder.exitListener(exitListener);
-      return this;
-    }
-
-    /**
-     * {@link AsyncProcessStartWaiter} used to block the thread until the asynchronous process has
-     * started successfully.
-     */
-    public Builder asyncProcessStartWaiter(AsyncProcessStartWaiter asyncProcessStartWaiter) {
-      this.processRunnerBuilder.asyncProcessStartWaiter(asyncProcessStartWaiter);
       return this;
     }
 


### PR DESCRIPTION
This fixes #60 which is about detecting when Dev App Server has started.
This also adds a builder to the DefaultProcesRunner.
Also fixes #63 

Notice that this adds a general mechanism for detecting when an asynchronously started operation has succeeded.

The clients are also no longer allowed to configure and provide the ProcessBuilder because if they set inheritIO to true, capturing output doesn't work. Instead, clients that need to consume the process output should use the ProcessOutputLineListener.

@loosebazooka @etanshaul 