### PR TITLE
Deploy restructuring idea, request for feedback

### DIFF
--- a/src/main/java/com/google/cloud/tools/app/deploy/Deploy.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/Deploy.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy;
+
+import com.google.cloud.tools.app.api.deploy.DeployConfiguration;
+import com.google.cloud.tools.app.deploy.process.OutputHandler;
+
+import java.util.concurrent.Future;
+
+// this is the API to deploy, it's assumed to be asynchronous and returns
+// a future to manipulate the process
+
+public interface Deploy {
+
+  Future<String> deploy(DeployConfiguration config);
+
+  // should this be part of the API? Getting non-result related output?
+  void setOutputHandler(OutputHandler handler);
+
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/Deploy.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/Deploy.java
@@ -17,18 +17,32 @@
 package com.google.cloud.tools.app.deploy;
 
 import com.google.cloud.tools.app.api.deploy.DeployConfiguration;
+import com.google.cloud.tools.app.deploy.gcloud.GcloudAppDeploy;
 import com.google.cloud.tools.app.deploy.process.OutputHandler;
+import com.google.cloud.tools.app.impl.cloudsdk.internal.sdk.CloudSdk;
 
 import java.util.concurrent.Future;
 
-// this is the API to deploy, it's assumed to be asynchronous and returns
-// a future to manipulate the process
+/**
+ * Created by appu on 5/24/16.
+ */
+public class Deploy {
 
-public interface Deploy {
+  // If there's a good way to configure the cloud SDK here instead of
+  // providing an object, we can explore that.
+  public static DeployRequestFactory newRequestFactory(CloudSdk sdk) {
+    return new GcloudAppDeploy.Builder(sdk);
+  }
 
-  Future<String> deploy(DeployConfiguration config);
+  private Deploy() {
+  }
 
-  // should this be part of the API? Getting non-result related output?
-  void setOutputHandler(OutputHandler handler);
+  public interface DeployRequestFactory {
+    DeployRequest newDeploymentRequest(DeployConfiguration config);
+  }
 
+  public interface DeployRequest {
+    DeployRequest setStatusUpdater(OutputHandler handler);
+    Future<DeployResult> deploy();
+  }
 }

--- a/src/main/java/com/google/cloud/tools/app/deploy/DeployExample.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/DeployExample.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy;
+
+import com.google.cloud.tools.app.deploy.gcloud.GcloudAppDeploy;
+import com.google.cloud.tools.app.deploy.process.LoggingOutputHandler;
+import com.google.cloud.tools.app.impl.cloudsdk.internal.sdk.CloudSdk;
+import com.google.cloud.tools.app.impl.config.DefaultDeployConfiguration;
+
+import java.io.File;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.logging.Level;
+
+public class DeployExample {
+
+  public static void howToUse() {
+    // presumably the sdk object comes from somewhere else, but lets build it here
+    // you can also set enviroment on it
+    CloudSdk sdk = new CloudSdk.Builder().sdkPath(new File("some/path")).build();
+
+    // create the deploy object
+    Deploy deploy = GcloudAppDeploy.newBuilder(sdk).build();
+
+    // set the output handler for non-result output
+    deploy.setOutputHandler(new LoggingOutputHandler("test", Level.INFO));
+
+    // start the deployment
+    Future<String> deployFuture = deploy.deploy(new DefaultDeployConfiguration());
+
+    try {
+      // get the result -- a waiting call
+      deployFuture.get();
+      // or kill it!
+      deployFuture.cancel(true);
+      // or whatever, I don't know, anything a future can do
+
+    } catch (InterruptedException | ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/DeployResult.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/DeployResult.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy;
+
+public class DeployResult {
+  // this can be whatever you want it to be, structured info
+  public String data;
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/gcloud/ConfigurationTranslator.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/gcloud/ConfigurationTranslator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.gcloud;
+
+/**
+ * Traslate a configuration into a readable form, we might have per type specific ones
+ * or maybe just use a single annotation based translator
+ * @param <T>
+ */
+public interface ConfigurationTranslator<T> {
+  String[] translate(T configuration);
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/gcloud/DeployResultConverter.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/gcloud/DeployResultConverter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.gcloud;
+
+import com.google.cloud.tools.app.deploy.DeployResult;
+import com.google.cloud.tools.app.deploy.gcloud.StringResultConverter;
+
+public class DeployResultConverter implements StringResultConverter<DeployResult> {
+
+  @Override
+  public DeployResult getResult(String result) {
+    DeployResult d = new DeployResult();
+    d.data = result;
+    return d;
+  }
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/gcloud/GcloudAppDeploy.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/gcloud/GcloudAppDeploy.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.gcloud;
+
+import com.google.cloud.tools.app.api.AppEngineException;
+import com.google.cloud.tools.app.api.deploy.DeployConfiguration;
+import com.google.cloud.tools.app.deploy.Deploy;
+import com.google.cloud.tools.app.deploy.process.CliProcessStarter;
+import com.google.cloud.tools.app.deploy.process.LoggingOutputHandler;
+import com.google.cloud.tools.app.deploy.process.OutputHandler;
+import com.google.cloud.tools.app.deploy.process.ProcessStarter;
+import com.google.cloud.tools.app.deploy.process.StreamConsumer;
+import com.google.cloud.tools.app.impl.cloudsdk.internal.sdk.CloudSdk;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.Future;
+import java.util.logging.Level;
+
+public class GcloudAppDeploy implements Deploy {
+  private final CloudSdk sdk;
+  private final ConfigurationTranslator<DeployConfiguration> configurationTranslator;
+  private OutputHandler outputHandler;
+  private ProcessStarter processStarter;
+
+  private GcloudAppDeploy(CloudSdk sdk,
+      ConfigurationTranslator<DeployConfiguration> configurationTranslator,
+      ProcessStarter processStarter) {
+    this.sdk = sdk;
+    this.processStarter = processStarter;
+    this.configurationTranslator = configurationTranslator;
+  }
+
+  @Override
+  public Future<String> deploy(DeployConfiguration config) {
+    try {
+      String[] command = sdk.createAppCommand("deploy", configurationTranslator.translate(config));
+      Process process = processStarter.startProcess(command);
+
+      if (outputHandler == null) {
+        outputHandler = new LoggingOutputHandler(GcloudAppDeploy.class.getName(), Level.INFO);
+      }
+      StreamConsumer.startNewConsumer(process.getErrorStream(), outputHandler);
+
+      return new GcloudFuture(process);
+
+    } catch(IOException e) {
+      throw new AppEngineException("Error deploying", e);
+    }
+  }
+
+  // It feels strange that this isn't part of the builder and is part of the deploy API? But I'm
+  // not sure what the right thing to do is. Should it be an implementation detail? or should the
+  // develop always have access to the output of the Deployer?
+  @Override
+  public void setOutputHandler(OutputHandler outputHandler) {
+    this.outputHandler = outputHandler;
+  }
+
+  public static Builder newBuilder(CloudSdk sdk) {
+    // there's probably some work to get the sdk refactored as storage for path/environment and stuff
+    return new Builder(sdk);
+  }
+
+  // this will probably be similar for all commands, but I don't know how to
+  // abstract it out yet, or if I even should?
+  public static class Builder {
+    private CloudSdk sdk;
+    private ProcessStarter processStarter;
+    private ConfigurationTranslator<DeployConfiguration> configurationTranslator;
+
+    private Builder(CloudSdk sdk) {
+      this.sdk = sdk;
+      // getEnvironment doesn't exist
+      this.processStarter = CliProcessStarter.newBuilder().environment(sdk.getEnvironment()).build();
+      this.configurationTranslator = new GcloudAppDeployTranslator();
+    }
+
+    public Builder processStarter(ProcessStarter processStarter) {
+      this.processStarter = processStarter;
+      return this;
+    }
+
+    public Builder configurationTranslator(
+        ConfigurationTranslator<DeployConfiguration> configurationTranslator) {
+      this.configurationTranslator = configurationTranslator;
+      return this;
+    }
+
+    public GcloudAppDeploy build() {
+      return new GcloudAppDeploy(sdk, configurationTranslator, processStarter);
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/gcloud/GcloudAppDeployTranslator.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/gcloud/GcloudAppDeployTranslator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.gcloud;
+
+import com.google.cloud.tools.app.api.deploy.DeployConfiguration;
+import com.google.cloud.tools.app.impl.cloudsdk.internal.args.GcloudArgs;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import java.io.File;
+import java.util.List;
+
+public class GcloudAppDeployTranslator implements ConfigurationTranslator<DeployConfiguration> {
+
+  @Override
+  public String[] translate(DeployConfiguration config) {
+    Preconditions.checkNotNull(config);
+    Preconditions.checkNotNull(config.getDeployables());
+    Preconditions.checkArgument(config.getDeployables().size() > 0);
+
+    List<String> arguments = Lists.newArrayList();
+    arguments.add("deploy");
+    for (File deployable : config.getDeployables()) {
+      if (!deployable.exists()) {
+        throw new IllegalArgumentException(
+            "Deployable " + deployable.toPath().toString() + " does not exist.");
+      }
+      arguments.add(deployable.toPath().toString());
+    }
+
+    arguments.addAll(GcloudArgs.get("bucket", config.getBucket()));
+    arguments.addAll(GcloudArgs.get("docker-build", config.getDockerBuild()));
+    arguments.addAll(GcloudArgs.get("force", config.getForce()));
+    arguments.addAll(GcloudArgs.get("image-url", config.getImageUrl()));
+    arguments.addAll(GcloudArgs.get("project", config.getProject()));
+    arguments.addAll(GcloudArgs.get("promote", config.getPromote()));
+    arguments.addAll(GcloudArgs.get("server", config.getServer()));
+    arguments.addAll(GcloudArgs.get("stop-previous-version", config.getStopPreviousVersion()));
+    arguments.addAll(GcloudArgs.get("version", config.getVersion()));
+
+    return arguments.toArray(new String[arguments.size()]);
+  }
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/gcloud/GcloudFuture.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/gcloud/GcloudFuture.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.gcloud;
+
+import com.google.cloud.tools.app.deploy.process.OutputHandler;
+import com.google.cloud.tools.app.deploy.process.StreamConsumer;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class GcloudFuture implements Future<String> {
+
+  // does this need to be synchronized some how when storing the result?
+
+  private List<String> result = Lists.newArrayList();
+  private final Process process;
+  private boolean cancelled = false;
+
+  public GcloudFuture(Process process) {
+    this.process = process;
+
+    StreamConsumer.startNewConsumer(process.getInputStream(), new OutputHandler() {
+      @Override
+      public void handleLine(String line) {
+        result.add(line);
+      }
+    });
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    if (!mayInterruptIfRunning) {
+      try {
+        process.exitValue();
+        return cancelled = false;
+      } catch(IllegalThreadStateException e) {
+        // we can continue to interrupt now
+      }
+    }
+    process.destroy();
+    return cancelled = true;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return cancelled;
+  }
+
+  @Override
+  public boolean isDone() {
+    try {
+      process.exitValue();
+      return true;
+    } catch(IllegalThreadStateException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public String get() throws InterruptedException, ExecutionException {
+    int exitCode = process.waitFor();
+    if (exitCode != 0) {
+      throw new ExecutionException("Process exited with code : " + exitCode, new Throwable());
+    }
+    return Joiner.on("\n").join(result);
+  }
+
+  @Override
+  public String get(long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    throw new UnsupportedOperationException("Process.waitFor has handing in java8, wait till then");
+  }
+
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/gcloud/StringResultConverter.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/gcloud/StringResultConverter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.gcloud;
+
+/**
+ * Created by appu on 5/24/16.
+ */
+public interface StringResultConverter<T> {
+
+  T getResult(String result);
+
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/process/CliProcessStarter.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/process/CliProcessStarter.java
@@ -24,13 +24,13 @@ import java.util.Map;
 // does give the shutdown hook option though
 public class CliProcessStarter implements ProcessStarter {
 
-  private final boolean enableShutdownHook;
+  private final boolean disableShutdownHook;
   private final Map<String, String> environment;
   private Process process;
 
-  private CliProcessStarter(Map<String, String> environment, boolean enableShutdownHook) {
+  private CliProcessStarter(Map<String, String> environment, boolean disableShutdownHook) {
     this.environment = environment;
-    this.enableShutdownHook = enableShutdownHook;
+    this.disableShutdownHook = disableShutdownHook;
   }
 
   @Override
@@ -39,7 +39,7 @@ public class CliProcessStarter implements ProcessStarter {
     pb.environment().putAll(environment);
     process = pb.start();
 
-    if (enableShutdownHook) {
+    if (!disableShutdownHook) {
       Runtime.getRuntime().addShutdownHook(new Thread("destroy-process") {
         @Override
         public void run() {
@@ -58,13 +58,13 @@ public class CliProcessStarter implements ProcessStarter {
   }
 
   public static class Builder {
-    private boolean enableShutdownHook = false;
+    private boolean disableShutdownHook;
     private Map<String, String> environment = Collections.emptyMap();
 
     private Builder() {}
 
-    public Builder enableShutdownHook() {
-      enableShutdownHook = true;
+    public Builder disableShutdownHook() {
+      disableShutdownHook = true;
       return this;
     }
 
@@ -74,7 +74,7 @@ public class CliProcessStarter implements ProcessStarter {
     }
 
     public CliProcessStarter build() {
-      return new CliProcessStarter(environment, enableShutdownHook);
+      return new CliProcessStarter(environment, disableShutdownHook);
     }
 
   }

--- a/src/main/java/com/google/cloud/tools/app/deploy/process/CliProcessStarter.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/process/CliProcessStarter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.process;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+// kind of a weird wrapper around ProcessBuilder, maybe we don't need to wrap at all?
+// does give the shutdown hook option though
+public class CliProcessStarter implements ProcessStarter {
+
+  private final boolean enableShutdownHook;
+  private final Map<String, String> environment;
+  private Process process;
+
+  private CliProcessStarter(Map<String, String> environment, boolean enableShutdownHook) {
+    this.environment = environment;
+    this.enableShutdownHook = enableShutdownHook;
+  }
+
+  @Override
+  public Process startProcess(String[] command) throws IOException {
+    ProcessBuilder pb = new ProcessBuilder(command);
+    pb.environment().putAll(environment);
+    process = pb.start();
+
+    if (enableShutdownHook) {
+      Runtime.getRuntime().addShutdownHook(new Thread("destroy-process") {
+        @Override
+        public void run() {
+          if (process != null) {
+            process.destroy();
+          }
+        }
+      });
+    }
+
+    return process;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private boolean enableShutdownHook = false;
+    private Map<String, String> environment = Collections.emptyMap();
+
+    private Builder() {}
+
+    public Builder enableShutdownHook() {
+      enableShutdownHook = true;
+      return this;
+    }
+
+    public Builder environment(Map<String, String> environment) {
+      this.environment = environment;
+      return this;
+    }
+
+    public CliProcessStarter build() {
+      return new CliProcessStarter(environment, enableShutdownHook);
+    }
+
+  }
+
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/process/LoggingOutputHandler.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/process/LoggingOutputHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.process;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class LoggingOutputHandler implements OutputHandler {
+
+  private final Logger log;
+  private final Level level;
+
+  public LoggingOutputHandler(String logName, Level logLevel) {
+    this.log = Logger.getLogger(logName);
+    this.level = logLevel;
+  }
+
+  @Override
+  public void handleLine(String line) {
+    log.log(level, line);
+  }
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/process/NullOutputHandler.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/process/NullOutputHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.process;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class NullOutputHandler implements OutputHandler {
+
+  @Override
+  public void handleLine(String line) {
+    // don't do anything
+  }
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/process/OutputHandler.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/process/OutputHandler.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.process;
+
+public interface OutputHandler {
+  void handleLine(String line);
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/process/PrintStreamOutputHandler.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/process/PrintStreamOutputHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.process;
+
+import java.io.PrintStream;
+
+public class PrintStreamOutputHandler implements OutputHandler {
+
+  PrintStream stream;
+
+  // use System.out, or System.err
+  public PrintStreamOutputHandler(PrintStream stream) {
+    this.stream = stream;
+  }
+
+  @Override
+  public void handleLine(String line) {
+    stream.println(line);
+  }
+}

--- a/src/main/java/com/google/cloud/tools/app/deploy/process/ProcessStarter.java
+++ b/src/main/java/com/google/cloud/tools/app/deploy/process/ProcessStarter.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.app.deploy.process;
+
+import java.io.IOException;
+
+public interface ProcessStarter {
+  Process startProcess(String[] command) throws IOException;
+}


### PR DESCRIPTION
@meltsufin @patflynn @etanshaul 

Looking at a review of the concept more than the actual code for this.

Take a look at DeployExample.java to start

the structure of the composition is basically :

- GcloudAppDeploy (Type: Deploy)
  - [required] CloudSdk
  - [optional] CliProcessStarter (Type: ProcesStarter)
  - [optional] DeployConfigurationTranslator (Type: ConfigurationTranslator)

1. CloudSdk right now if from the existing code, not much will change, execution is taken out of it though.
1. CliProcessStarter can configure two things, the jvm shutdown hook (most only disabled when running the devappserver in background mode) and the process environment
1. DeployConfigurationTranslator translates a deploy configuration to a cli


Theres some notes in the source files too. You can ignore build errors, some methods I just made up.

Also some of this stuff might conflict with things I preferred in earlier code reviews (like: inheritted stdout/stderr in process builder), so, yeah, sorry.