### PR TITLE
[OSGi] Export .impl.* packages but marked as internal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,10 @@
           <instructions>
             <Bundle-SymbolicName>com.google.cloud.tools.app.lib</Bundle-SymbolicName>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
+            <Export-Package>
+              com.google.cloud.tools.app.impl.*;x-internal:=true;-noimport:=true,
+              com.google.cloud.tools.app.*
+            </Export-Package>
           </instructions>
         </configuration>
         <executions>


### PR DESCRIPTION
I'm now starting to integrate `app-tools-lib-for-java` for the `GoogleCloudPlatform/gcloud-eclipse-tools` tooling.  It looks like need to access classes in `.impl`, particularly the `CloudSdk` class at the very least.  I've changed up the OSGi metadata to export the `.impl` packages but in such a way that they're flagged as being internal classes, which produces a warning in Eclipse, using the same setup used by Eclipse-provided bundles.