### PR TITLE
Restore CloudSdk#validate() and accompanying CloudSdkConfigurationException

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -192,7 +192,7 @@ public class CloudSdk {
   }
 
   /**
-   * Validate the current instance
+   * Validate the current instance.
    * 
    * @throws CloudSdkConfigurationException if invalid
    */

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -191,6 +191,38 @@ public class CloudSdk {
     return getJavaAppEngineSdkPath().resolve(JAVA_TOOLS_JAR);
   }
 
+  /**
+   * Validate the current instance
+   * 
+   * @throws CloudSdkConfigurationException if invalid
+   */
+  public void validate() throws CloudSdkConfigurationException {
+    if (sdkPath == null) {
+      throw new CloudSdkConfigurationException("Validation Error : Sdk path is null");
+    }
+    if (!sdkPath.toFile().isDirectory()) {
+      throw new CloudSdkConfigurationException(
+          "Validation Error : Sdk directory '" + sdkPath + "' is not valid");
+    }
+    if (!getGCloudPath().toFile().isFile()) {
+      throw new CloudSdkConfigurationException(
+          "Validation Error : gcloud path '" + getGCloudPath() + "' is not valid");
+    }
+    if (!getDevAppServerPath().toFile().isFile()) {
+      throw new CloudSdkConfigurationException(
+          "Validation Error : dev_appserver.py path '" + getDevAppServerPath() + "' is not valid");
+    }
+    if (!getJavaAppEngineSdkPath().toFile().isFile()) {
+      throw new CloudSdkConfigurationException("Validation Error : Java App Engine SDK path '"
+          + getJavaAppEngineSdkPath() + "' is not valid");
+    }
+    if (!getJavaToolsJar().toFile().isFile()) {
+      throw new CloudSdkConfigurationException(
+          "Validation Error : Java Tools jar path '" + getJavaToolsJar() + "' is not valid");
+    }
+  }
+
+
   public static class Builder {
     private Path sdkPath;
     private String appCommandMetricsEnvironment;

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkConfigurationException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkConfigurationException.java
@@ -28,10 +28,6 @@ public class CloudSdkConfigurationException extends RuntimeException {
     super(message, cause);
   }
 
-  public CloudSdkConfigurationException(Throwable cause) {
-    super(cause);
-  }
-
   protected CloudSdkConfigurationException(String message, Throwable cause,
       boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkConfigurationException.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkConfigurationException.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk;
+
+/**
+ * Thrown when the Google Cloud SDK location does not appear to be valid.
+ */
+public class CloudSdkConfigurationException extends RuntimeException {
+  private static final long serialVersionUID = 249822403347062566L;
+
+  public CloudSdkConfigurationException(String message) {
+    super(message);
+  }
+
+  public CloudSdkConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public CloudSdkConfigurationException(Throwable cause) {
+    super(cause);
+  }
+
+  protected CloudSdkConfigurationException(String message, Throwable cause,
+      boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+}


### PR DESCRIPTION
This patch restores `validate()`, which was removed in commit 35581d13bbd03196fd1d2eaffe5032c72c26e4b8.  I didn't touch the messages passed into `CloudSdkConfigurationException`, though they're not i18n friendly.

Fixes #118 