### PR TITLE
[OSGi] Avoid importing javax.annotation to prevent problems from split packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
           <instructions>
             <Bundle-SymbolicName>com.google.cloud.tools.app.lib</Bundle-SymbolicName>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
+            <Import-Package>!javax.annotation,*</Import-Package>
           </instructions>
         </configuration>
         <executions>


### PR DESCRIPTION
Commit be94e074b8856751f4f9e77c41d6045a1900abb2 marked a field as `@Nullable`, which caused the generated OSGi metadata to include an `Import-Package: javax.annotation`.  `java.annotation.Nullable` is one of the annotations proposed by JSR 305, and whose implementation is provided by the FindBugs project in a OSGi bundle called `org.jsr-305`.  Unfortunately other bundles define `javax.annotation` and so we have a split package situation, which is never fun.

This patch adjusts the OSGi metadata-generation process to not remove the `javax.annotation` package from the required imports.  It turns out the JSR 305 annotations don't actually have to be present at runtime.  The only consequence  is that any attempts to fetch the annotations at runtime via `java.lang.reflect` will not see the JSR 305 `javax.annotation` classes.  This is a much simpler solution than that proposed in https://github.com/GoogleCloudPlatform/gcloud-eclipse-tools/pull/261

I see this is a short-to-medium term fix.  I've filed a [bug against FindBugs](https://sourceforge.net/p/findbugs/bugs/1454/) to see about having appropriate modifiers on their OSGi metadata so that just the JSR 305 portion of `javax.annotation` can be imported.

PTAL @chanseokoh 