### PR TITLE
Copy all App Engine supported files for staging

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/api/deploy/DefaultStageFlexibleConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/deploy/DefaultStageFlexibleConfiguration.java
@@ -29,7 +29,7 @@ public class DefaultStageFlexibleConfiguration implements StageFlexibleConfigura
   private File stagingDirectory;
 
   @Override
-  public File getAppYaml() {
+  public File getAppEngineDirectory() {
     return appYaml;
   }
 

--- a/src/main/java/com/google/cloud/tools/appengine/api/deploy/StageFlexibleConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/appengine/api/deploy/StageFlexibleConfiguration.java
@@ -21,7 +21,7 @@ import java.io.File;
  */
 public interface StageFlexibleConfiguration {
 
-  File getAppYaml();
+  File getAppEngineDirectory();
 
   File getDockerDirectory();
 


### PR DESCRIPTION
Fixes #96. 

The clients now have to specify an App Engine config directory instead of an app.yaml path for flexible staging.