### PR TITLE
If runtime is java, set runtime config to openjdk8 in app.yaml

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineStandardStaging.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkAppEngineStandardStaging.java
@@ -21,9 +21,12 @@ import com.google.cloud.tools.appengine.api.deploy.AppEngineStandardStaging;
 import com.google.cloud.tools.appengine.api.deploy.StageStandardConfiguration;
 import com.google.cloud.tools.appengine.cloudsdk.internal.args.AppCfgArgs;
 import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerException;
+import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -79,6 +82,13 @@ public class CloudSdkAppEngineStandardStaging implements AppEngineStandardStagin
       }
 
       cloudSdk.runAppCfgCommand(arguments);
+
+      //TODO : Move this fix up the chain (appcfg)
+      if (config.getRuntime() != null && config.getRuntime().equals("java")) {
+        File appYaml = new File(config.getStagingDirectory(), "app.yaml");
+        com.google.common.io.Files
+            .append("\nruntime_config:\n  jdk: openjdk8\n", appYaml, Charsets.UTF_8);
+      }
 
     } catch (IOException | ProcessRunnerException e) {
       throw new AppEngineException(e);


### PR DESCRIPTION
This is a change that we should push up to appcfg/staging or into
gcloud. No tool at the moment appears to be building a dockerfile
with runtime:java and vm:true that is correct. By forcing the jdk
to be openjdk8 we trigger the creation of a Dockerfile with the
correct java8jetty9 image.