### PR TITLE
Make getSdkPath and getJavaToolsJar public.

### DIFF
--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -251,10 +251,12 @@ public class CloudSdk {
 
     /**
      * The home directory of Google Cloud SDK.
+     *
+     * @param sdkPath the root path for the Cloud SDK
      */
-    public Builder sdkPath(Path sdkPathFile) {
-      if (sdkPathFile != null) {
-        this.sdkPath = sdkPathFile;
+    public Builder sdkPath(Path sdkPath) {
+      if (sdkPath != null) {
+        this.sdkPath = sdkPath;
       }
       return this;
     }
@@ -352,7 +354,7 @@ public class CloudSdk {
     /**
      * Create a new instance of {@link CloudSdk}.
      *
-     * If {@code sdKPath} is not set, this method will attempt to look for the SDK in known install
+     * <p>If {@code sdKPath} is not set, this method will look for the SDK in known install
      * locations.
      */
     public CloudSdk build() {

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.appengine.cloudsdk.internal.process.WaitingProcess
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessExitListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 
@@ -175,7 +176,7 @@ public class CloudSdk {
     logger.info("submitting command: " + WHITESPACE_JOINER.join(command));
   }
 
-  private Path getSdkPath() {
+  @VisibleForTesting public Path getSdkPath() {
     return sdkPath;
   }
 
@@ -195,7 +196,7 @@ public class CloudSdk {
     return getSdkPath().resolve(JAVA_APPENGINE_SDK_PATH);
   }
 
-  private Path getJavaToolsJar() {
+  public Path getJavaToolsJar() {
     return getJavaAppEngineSdkPath().resolve(JAVA_TOOLS_JAR);
   }
 
@@ -253,9 +254,9 @@ public class CloudSdk {
      * The home directory of Google Cloud SDK. If not set, will attempt to look for the SDK in known
      * install locations.
      */
-    public Builder sdkPath(File sdkPathFile) {
+    public Builder sdkPath(Path sdkPathFile) {
       if (sdkPathFile != null) {
-        this.sdkPath = sdkPathFile.toPath();
+        this.sdkPath = sdkPathFile;
       }
       return this;
     }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -231,7 +231,7 @@ public class CloudSdk {
     }
     if (!Files.isDirectory(sdkPath)) {
       throw new AppEngineException(
-          "Validation Error: SDK location '" + sdkPath + "' is a directory.");
+          "Validation Error: SDK location '" + sdkPath + "' is not a directory.");
     }
     if (!Files.isRegularFile(getGCloudPath())) {
       throw new AppEngineException(
@@ -373,7 +373,7 @@ public class CloudSdk {
     /**
      * Create a new instance of {@link CloudSdk}.
      *
-     * <p>If {@code sdKPath} is not set, this method will look for the SDK in known install
+     * <p>If {@code sdkPath} is not set, this method will look for the SDK in known install
      * locations.
      */
     public CloudSdk build() {

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -29,6 +29,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -96,6 +97,8 @@ public class CloudSdk {
         exitListeners, startListeners);
 
     // Populate jar locations.
+    // TODO(joaomartins): Consider case where SDK doesn't contain these jars. Only App Engine
+    // SDK does.
     JAR_LOCATIONS.put("servlet-api.jar",
             getJavaAppEngineSdkPath().resolve("shared/servlet-api.jar"));
     JAR_LOCATIONS.put("jsp-api.jar", getJavaAppEngineSdkPath().resolve("shared/jsp-api.jar"));
@@ -226,27 +229,28 @@ public class CloudSdk {
     if (sdkPath == null) {
       throw new AppEngineException("Validation Error: SDK path is null");
     }
-    if (!sdkPath.toFile().isDirectory()) {
+    if (!Files.isDirectory(sdkPath)) {
       throw new AppEngineException(
-          "Validation Error: SDK directory '" + sdkPath + "' is not valid");
+          "Validation Error: SDK location '" + sdkPath + "' is a directory.");
     }
-    if (!getGCloudPath().toFile().isFile()) {
+    if (!Files.isRegularFile(getGCloudPath())) {
       throw new AppEngineException(
-          "Validation Error: gcloud path '" + getGCloudPath() + "' is not valid");
+          "Validation Error: gcloud location '" + getGCloudPath() + "' is not a file.");
     }
-    if (!getDevAppServerPath().toFile().isFile()) {
+    if (!Files.isRegularFile(getDevAppServerPath())) {
       throw new AppEngineException(
-          "Validation Error: dev_appserver.py path '" + getDevAppServerPath() + "' is not valid");
+          "Validation Error: dev_appserver.py location '"
+              + getDevAppServerPath() + "' is not a file.");
     }
-    if (!getJavaAppEngineSdkPath().toFile().isDirectory()) {
+    if (!Files.isDirectory(getJavaAppEngineSdkPath())) {
       throw new AppEngineException(
-          "Validation Error: Java App Engine SDK path '" + getJavaAppEngineSdkPath()
-              + "' is not valid");
+          "Validation Error: Java App Engine SDK location '"
+              + getJavaAppEngineSdkPath() + "' is not a directory.");
     }
-    if (!JAR_LOCATIONS.get(JAVA_TOOLS_JAR).toFile().isFile()) {
+    if (!Files.isRegularFile(JAR_LOCATIONS.get(JAVA_TOOLS_JAR))) {
       throw new AppEngineException(
-          "Validation Error: Java Tools jar path '"
-                  + JAR_LOCATIONS.get(JAVA_TOOLS_JAR) + "' is not valid");
+          "Validation Error: Java Tools jar location '"
+                  + JAR_LOCATIONS.get(JAVA_TOOLS_JAR) + "' is not a file.");
     }
   }
 

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -25,7 +25,6 @@ import com.google.cloud.tools.appengine.cloudsdk.internal.process.WaitingProcess
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessExitListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 
@@ -176,7 +175,7 @@ public class CloudSdk {
     logger.info("submitting command: " + WHITESPACE_JOINER.join(command));
   }
 
-  @VisibleForTesting public Path getSdkPath() {
+  public Path getSdkPath() {
     return sdkPath;
   }
 
@@ -251,8 +250,7 @@ public class CloudSdk {
     private int runDevAppServerWaitSeconds;
 
     /**
-     * The home directory of Google Cloud SDK. If not set, will attempt to look for the SDK in known
-     * install locations.
+     * The home directory of Google Cloud SDK.
      */
     public Builder sdkPath(Path sdkPathFile) {
       if (sdkPathFile != null) {
@@ -353,6 +351,9 @@ public class CloudSdk {
 
     /**
      * Create a new instance of {@link CloudSdk}.
+     *
+     * If {@code sdKPath} is not set, this method will attempt to look for the SDK in known install
+     * locations.
      */
     public CloudSdk build() {
 

--- a/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
+++ b/src/test/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkTest.java
@@ -1,0 +1,40 @@
+package com.google.cloud.tools.appengine.cloudsdk;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Unit tests for {@link CloudSdk}
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CloudSdkTest {
+  @Test
+  public void testGetSdkPath() {
+    Path location = Paths.get("/");
+    CloudSdk sdk = new CloudSdk.Builder().sdkPath(location).build();
+    assertEquals(location, sdk.getSdkPath());
+  }
+
+  @Test
+  public void testGetJavaAppEngineSdkPath() {
+    Path location = Paths.get("/");
+    CloudSdk sdk = new CloudSdk.Builder().sdkPath(location).build();
+    assertEquals(location.resolve("platform/google_appengine/google/appengine/tools/java/lib"),
+        sdk.getJavaAppEngineSdkPath());
+  }
+
+  @Test
+  public void testGetJarPathJavaTools() {
+    Path location = Paths.get("/");
+    CloudSdk sdk = new CloudSdk.Builder().sdkPath(location).build();
+    assertEquals(Paths.get("/platform/google_appengine/google/appengine"
+        + "/tools/java/lib/appengine-tools-api.jar"),
+        sdk.getJarPath("appengine-tools-api.jar"));
+  }
+}


### PR DESCRIPTION
getSdkPath should only be used for testing in https://github.com/GoogleCloudPlatform/gcloud-eclipse-tools/pull/335

@meltsufin @loosebazooka PTAL