### PR TITLE
Allow configuring other strategies for finding the Google Cloud SDK.

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -18,6 +18,7 @@
   <Match>
     <Or>
       <Bug pattern="DM_STRING_CTOR"/>
+      <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE"/>
     </Or>
   </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -174,10 +174,15 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>3.0.1</version>
         <configuration>
+          <!--
+             Register as an Eclipse Buddy to allow discovery of CloudSdkResolver
+             instances from other bundles.
+          -->
           <instructions>
             <Bundle-SymbolicName>com.google.cloud.tools.app.lib</Bundle-SymbolicName>
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
             <Import-Package>!javax.annotation,*</Import-Package>
+            <Eclipse-BuddyPolicy>registered</Eclipse-BuddyPolicy>
           </instructions>
         </configuration>
         <executions>

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -31,7 +31,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import java.io.File;
-import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -456,12 +455,11 @@ public class CloudSdk {
   /**
    * Compare two {@link CloudSdkResolver} instances by their rank.
    */
-  private static class ResolverComparator implements Comparator<CloudSdkResolver>, Serializable {
-    private static final long serialVersionUID = -4414214946468755954L;
-
+  private static class ResolverComparator implements Comparator<CloudSdkResolver> {
     @Override
     public int compare(CloudSdkResolver o1, CloudSdkResolver o2) {
       return o1.getRank() - o2.getRank();
     }
+
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -453,7 +453,7 @@ public class CloudSdk {
   }
 
   /**
-   * Compare two {@link CloudSdkResolver} instances by their rank
+   * Compare two {@link CloudSdkResolver} instances by their rank.
    */
   private static class ResolverComparator implements Comparator<CloudSdkResolver> {
     @Override

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -412,7 +412,7 @@ public class CloudSdk {
           if (discoveredSdkPath != null) {
             return discoveredSdkPath;
           }
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
           // prevent interference from exceptions in other resolvers
           logger.log(Level.SEVERE, resolver.getClass().getName()
               + ": exception thrown when searching for Google Cloud SDK", ex);

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdk.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import java.io.File;
+import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -455,11 +456,12 @@ public class CloudSdk {
   /**
    * Compare two {@link CloudSdkResolver} instances by their rank.
    */
-  private static class ResolverComparator implements Comparator<CloudSdkResolver> {
+  private static class ResolverComparator implements Comparator<CloudSdkResolver>, Serializable {
+    private static final long serialVersionUID = -4414214946468755954L;
+
     @Override
     public int compare(CloudSdkResolver o1, CloudSdkResolver o2) {
       return o1.getRank() - o2.getRank();
     }
-
   }
 }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkResolver.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.appengine.cloudsdk;
+
+import java.nio.file.Path;
+
+/**
+ * Resolve paths with CloudSdk and Python defaults.
+ */
+public interface CloudSdkResolver {
+
+  /**
+   * Attempts to find the path to Google Cloud SDK.
+   *
+   * @return Path to Google Cloud SDK or null
+   */
+  public Path getCloudSdkPath();
+}

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkResolver.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/CloudSdkResolver.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.appengine.cloudsdk;
 import java.nio.file.Path;
 
 /**
- * Resolve paths with CloudSdk and Python defaults.
+ * Resolve paths find the CloudSdk.
  */
 public interface CloudSdkResolver {
 
@@ -28,5 +28,10 @@ public interface CloudSdkResolver {
    *
    * @return Path to Google Cloud SDK or null
    */
-  public Path getCloudSdkPath();
+  Path getCloudSdkPath();
+
+  /**
+   * Provides a rank for ordering a set of {@link CloudSdkResolver}s.
+   */
+  int getRank();
 }

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/PathResolver.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/PathResolver.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * Resolve paths with CloudSdk and Python defaults.
  */
-public class PathResolver {
+public class PathResolver implements CloudSdkResolver {
 
   /**
    * Attempts to find the path to Google Cloud SDK.

--- a/src/main/java/com/google/cloud/tools/appengine/cloudsdk/PathResolver.java
+++ b/src/main/java/com/google/cloud/tools/appengine/cloudsdk/PathResolver.java
@@ -93,4 +93,11 @@ public class PathResolver implements CloudSdkResolver {
     }
     return null;
   }
+
+  @Override
+  public int getRank() {
+    // Should be near-last but allow option for last-ditch resolvers that may choose
+    // to prompt the user for a location
+    return Integer.MAX_VALUE / 2;
+  }
 }


### PR DESCRIPTION
Currently the Eclipse Tooling has wrapper classes (`CloudSdkProvider` and `CloudSdkPrompter`) for resolving the Google Cloud SDK using a user-provided location.  This solution is error-prone as all code that tries to obtain a `CloudSdk` instance must funnel through these wrapper classes.  Failures occur if there are any code paths that uses the `CloudSdk.Builder` directly.

This patch extracts an interface `CloudSdkResolver` modelled on PathResolver.  The `CloudSdk` instance looks up additional `CloudSdkResolver` classes using the standard `java.util.ServiceLoader` mechanism.  To support registering resolvers under Eclipse, where we have separate class loaders, we register the bundle using the Eclipse Buddy Policy; additional resolvers can also be contributed using OSGi fragments.

Update: Fixes #169